### PR TITLE
Update for CUDA 13.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-compat" %}
 {% set driver_version = "610.43.02" %}
-{% set cuda_version = "13.3.1" %}
+{% set cuda_version = "13.3" %}
 {% set cuda_major_minor = cuda_version.split('.')[:2] | join('.') %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]


### PR DESCRIPTION
Automated update to 610.43.02 via CapsLock.

xref: https://github.com/conda-forge/cuda-feedstock/issues/119