### PR TITLE
Add Tegra variant using the `cuda_compat_orin` redistributable

### DIFF
--- a/.ci_support/linux_aarch64_arm_variant_typesbsa.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsa.yaml
@@ -1,0 +1,27 @@
+arm_variant_type:
+- sbsa
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+target_platform:
+- linux-aarch64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_arm_variant_typetegra.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typetegra.yaml
@@ -1,3 +1,5 @@
+arm_variant_type:
+- tegra
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -34,7 +34,19 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_aarch64_
+          - CONFIG: linux_aarch64_arm_variant_typesbsa
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
+          - CONFIG: linux_aarch64_arm_variant_typetegra
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ older display drivers. Used for data center GPUs and, with the `tegra`
 variant, for Jetson devices still running a JetPack 6 / L4T driver.
 
 The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
-Until this package ships an activation script, they are picked up only if that
-directory is prepended to `LD_LIBRARY_PATH`.
+They are picked up only if that directory is prepended to `LD_LIBRARY_PATH`.
 
 
 Current build status

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ compatibility. This compatibility enables newer CUDA runtimes to work with
 older display drivers. Used for data center GPUs and, with the `tegra`
 variant, for Jetson devices still running a JetPack 6 / L4T driver.
 
+The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
+Until this package ships an activation script, they are picked up only if that
+directory is prepended to `LD_LIBRARY_PATH`.
+
 
 Current build status
 ====================

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Documentation: https://docs.nvidia.com/cuda/index.html
 
 Package containing all the necessary CUDA driver files related to forward
 compatibility. This compatibility enables newer CUDA runtimes to work with
-older display drivers. Used for Tesla cards only.
+older display drivers. Used for data center GPUs and, with the `tegra`
+variant, for Jetson devices still running a JetPack 6 / L4T driver.
 
 
 Current build status

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,8 +6,14 @@ set -ex
 [[ -d lib64 ]] && mv lib64 lib
 mkdir -p ${PREFIX}/cuda-compat
 
-# The Tegra redistributable unpacks its libraries into compat_orin instead of compat.
-COMPAT_DIR="${COMPAT_DIR:-compat}"
+# The redistributable unpacks its libraries into "compat", except the Tegra one which uses
+# "compat_orin".
+compat_dirs=(compat*/)
+if [[ ${#compat_dirs[@]} -ne 1 || ! -d ${compat_dirs[0]} ]]; then
+  echo "Expected exactly one compat directory, found: ${compat_dirs[*]}" >&2
+  exit 1
+fi
+COMPAT_DIR=${compat_dirs[0]}
 
 check-glibc ${COMPAT_DIR}/*.so*
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,9 @@ set -ex
 [[ -d lib64 ]] && mv lib64 lib
 mkdir -p ${PREFIX}/cuda-compat
 
-check-glibc compat/*.so.*
+# The Tegra redistributable unpacks its libraries into compat_orin instead of compat.
+COMPAT_DIR="${COMPAT_DIR:-compat}"
 
-cp -vd compat/*.so* ${PREFIX}/cuda-compat/
+check-glibc ${COMPAT_DIR}/*.so*
+
+cp -vd ${COMPAT_DIR}/*.so* ${PREFIX}/cuda-compat/

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,9 @@
 c_stdlib_version:  # [linux]
   - "2.28"         # [linux]
+
+# Build both the SBSA (data center ARM) and the Tegra (Jetson) flavours of the
+# forward compatibility package. They come from different NVIDIA
+# redistributables and are mutually exclusive at install time via `arm-variant`.
+arm_variant_type:  # [aarch64]
+  - sbsa           # [aarch64]
+  - tegra          # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,20 +7,40 @@
 {% set platform = "linux-sbsa" %}  # [aarch64]
 {% set extension = "tar.xz" %}  # [not win]
 
+# Discrete GPUs get forward compatibility from the "cuda_compat" redistributable, which is
+# versioned after the user-mode driver it ships.
+{% set component = "cuda_compat" %}
+{% set component_version = driver_version + "_cuda" + cuda_major_minor %}
+{% set compat_dir = "compat" %}
+{% set impl_version = driver_version %}
+
+# Tegra cannot reuse the SBSA archive: its libcuda is built against the L4T kernel driver and links
+# against the Tegra NVRM stack (libnvrm_gpu, libnvrm_mem, ...), which is absent on server ARM. NVIDIA
+# therefore ships the separate "cuda_compat_orin" redistributable, the only supported way to run a
+# CUDA 13 runtime on a Jetson Orin still on JetPack 6. Since CUDA 13 unified the Tegra and SBSA
+# toolkits it is published under the "linux-sbsa" platform directory, but it keeps its own layout:
+# it is versioned after the CUDA release instead of the driver, and it unpacks into "compat_orin".
+{% set component = "cuda_compat_orin" %}       # [aarch64 and arm_variant_type == "tegra"]
+{% set component_version = "13.3.45405995" %}  # [aarch64 and arm_variant_type == "tegra"]
+{% set compat_dir = "compat_orin" %}           # [aarch64 and arm_variant_type == "tegra"]
+{% set impl_version = "610.01" %}              # [aarch64 and arm_variant_type == "tegra"]
+
 package:
   name: {{ name|lower }}-split
   version: {{ cuda_version }}
 
 source:
-  url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_compat/{{ platform }}/cuda_compat-{{ platform }}-{{ driver_version }}_cuda{{ cuda_major_minor }}-archive.{{ extension }}
+  url: https://developer.download.nvidia.com/compute/cuda/redist/{{ component }}/{{ platform }}/{{ component }}-{{ platform }}-{{ component_version }}-archive.{{ extension }}
   sha256: 39a959840ed06b37ccde9b84c083babe415160c6907517cefc463da6d7dc2342  # [linux64]
-  sha256: 98b044e17e3b9d7ef27ad9bfd231af966744c9fb05b70fb43b5a000dd087952b  # [aarch64]
+  sha256: 98b044e17e3b9d7ef27ad9bfd231af966744c9fb05b70fb43b5a000dd087952b  # [aarch64 and arm_variant_type == "sbsa"]
+  sha256: d9e7655f46c10eeda7c3652f4fce91825f2b446fab8976c4591bfd4b887e4c8d  # [aarch64 and arm_variant_type == "tegra"]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx or win or ppc64le]
   script_env:
-    - DRV_VERSION={{ driver_version }}
+    - DRV_VERSION={{ impl_version }}
+    - COMPAT_DIR={{ compat_dir }}
 
 requirements:
   build:
@@ -31,6 +51,7 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("cuda-compat-impl", exact=True) }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - exit 0
@@ -43,41 +64,58 @@ outputs:
       description: |
         Package containing all the necessary CUDA driver files related to forward
         compatibility. This compatibility enables newer CUDA runtimes to work with
-        older display drivers. Used for Tesla cards only.
+        older display drivers. Used for data center GPUs and, with the `tegra`
+        variant, for Jetson devices still running a JetPack 6 / L4T driver.
       doc_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-compat-impl
-    version: {{ driver_version }}
+    version: {{ impl_version }}
     files:
       - cuda-compat
     build:
-      # The libnvidia-pkcs11* libs optionally dlopen OpenSSL at runtime.
+      # The libnvidia-pkcs11* libs optionally dlopen OpenSSL at runtime. The Tegra libs additionally
+      # link against the L4T NVRM stack and the DLA runtime, which ship with the JetPack BSP on the
+      # device and are resolved there through the system loader configuration.
       missing_dso_allowlist:
         - '*/libcuda.so*'
         - '*/libcrypto.so*'
+        - '*/libnvcuextend.so'      # [aarch64 and arm_variant_type == "tegra"]
+        - '*/libnvdla_runtime.so'   # [aarch64 and arm_variant_type == "tegra"]
+        - '*/libnvrm_gpu.so'        # [aarch64 and arm_variant_type == "tegra"]
+        - '*/libnvrm_host1x.so'     # [aarch64 and arm_variant_type == "tegra"]
+        - '*/libnvrm_mem.so'        # [aarch64 and arm_variant_type == "tegra"]
+        - '*/libnvrm_sync.so'       # [aarch64 and arm_variant_type == "tegra"]
     requirements:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
+      run:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -f $PREFIX/cuda-compat/libcuda.so.{{ driver_version }}
+        # The Tegra libcuda keeps the L4T SONAME libcuda.so.1.1 instead of being versioned after the
+        # driver, and libcudadebugger.so.1 is a regular file there rather than a symlink.
+        - test -f $PREFIX/cuda-compat/libcuda.so.{{ impl_version }}                      # [not (aarch64 and arm_variant_type == "tegra")]
+        - test -f $PREFIX/cuda-compat/libcuda.so.1.1                                     # [aarch64 and arm_variant_type == "tegra"]
         - test -L $PREFIX/cuda-compat/libcuda.so.1
         - test -L $PREFIX/cuda-compat/libcuda.so
-        - test -f $PREFIX/cuda-compat/libnvidia-nvvm.so.{{ driver_version }}
+        - test -f $PREFIX/cuda-compat/libnvidia-nvvm.so.{{ impl_version }}
         - test -L $PREFIX/cuda-compat/libnvidia-nvvm.so.4
         - test -L $PREFIX/cuda-compat/libnvidia-nvvm.so
-        - test -f $PREFIX/cuda-compat/libnvidia-ptxjitcompiler.so.{{ driver_version }}
+        - test -f $PREFIX/cuda-compat/libnvidia-ptxjitcompiler.so.{{ impl_version }}
         - test -L $PREFIX/cuda-compat/libnvidia-ptxjitcompiler.so.1
-        - test -f $PREFIX/cuda-compat/libnvidia-tileiras.so.{{ driver_version }}
-        - test -f $PREFIX/cuda-compat/libnvidia-gpucomp.so.{{ driver_version }}
+        - test -f $PREFIX/cuda-compat/libnvidia-tileiras.so.{{ impl_version }}
+        - test -f $PREFIX/cuda-compat/libnvidia-gpucomp.so.{{ impl_version }}
         - test -f $PREFIX/cuda-compat/libnvidia-nvvm70.so.4
-        - test -f $PREFIX/cuda-compat/libnvidia-nvvm.so.{{ driver_version }}
-        - test -f $PREFIX/cuda-compat/libnvidia-pkcs11.so.{{ driver_version }}           # [linux64]
-        - test -f $PREFIX/cuda-compat/libnvidia-pkcs11-openssl3.so.{{ driver_version }}  # [linux64]
-        - test -f $PREFIX/cuda-compat/libcudadebugger.so.{{ driver_version }}
-        - test -L $PREFIX/cuda-compat/libcudadebugger.so.1
+        - test -f $PREFIX/cuda-compat/libnvidia-pkcs11.so.{{ impl_version }}             # [linux64]
+        - test -f $PREFIX/cuda-compat/libnvidia-pkcs11-openssl3.so.{{ impl_version }}    # [linux64]
+        - test -f $PREFIX/cuda-compat/libcudadebugger.so.{{ impl_version }}              # [not (aarch64 and arm_variant_type == "tegra")]
+        - test -L $PREFIX/cuda-compat/libcudadebugger.so.1                               # [not (aarch64 and arm_variant_type == "tegra")]
+        - test -f $PREFIX/cuda-compat/libcudadebugger.so.1                               # [aarch64 and arm_variant_type == "tegra"]
+        # Only Tegra ships the cuDLA bridge and the NVRM interop shim.
+        - test -f $PREFIX/cuda-compat/libnvcudla.so                                      # [aarch64 and arm_variant_type == "tegra"]
+        - test -f $PREFIX/cuda-compat/libnvcuextend.so                                   # [aarch64 and arm_variant_type == "tegra"]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE
@@ -87,7 +125,8 @@ outputs:
       description: |
         Package containing all the necessary CUDA driver files related to forward
         compatibility. This compatibility enables newer CUDA runtimes to work with
-        older display drivers. Used for Tesla cards only.
+        older display drivers. Used for data center GPUs and, with the `tegra`
+        variant, for Jetson devices still running a JetPack 6 / L4T driver.
       doc_url: https://docs.nvidia.com/cuda/index.html
 
 about:
@@ -99,7 +138,8 @@ about:
   description: |
     Package containing all the necessary CUDA driver files related to forward
     compatibility. This compatibility enables newer CUDA runtimes to work with
-    older display drivers. Used for Tesla cards only.
+    older display drivers. Used for data center GPUs and, with the `tegra`
+    variant, for Jetson devices still running a JetPack 6 / L4T driver.
   doc_url: https://docs.nvidia.com/cuda/index.html
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,8 +72,7 @@ outputs:
         variant, for Jetson devices still running a JetPack 6 / L4T driver.
 
         The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
-        Until this package ships an activation script, they are picked up only if that
-        directory is prepended to `LD_LIBRARY_PATH`.
+        They are picked up only if that directory is prepended to `LD_LIBRARY_PATH`.
       doc_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-compat-impl
@@ -154,8 +153,7 @@ outputs:
         variant, for Jetson devices still running a JetPack 6 / L4T driver.
 
         The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
-        Until this package ships an activation script, they are picked up only if that
-        directory is prepended to `LD_LIBRARY_PATH`.
+        They are picked up only if that directory is prepended to `LD_LIBRARY_PATH`.
       doc_url: https://docs.nvidia.com/cuda/index.html
 
 about:
@@ -171,8 +169,7 @@ about:
     variant, for Jetson devices still running a JetPack 6 / L4T driver.
 
     The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
-    Until this package ships an activation script, they are picked up only if that
-    directory is prepended to `LD_LIBRARY_PATH`.
+    They are picked up only if that directory is prepended to `LD_LIBRARY_PATH`.
   doc_url: https://docs.nvidia.com/cuda/index.html
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,43 +1,48 @@
 {% set name = "cuda-compat" %}
-{% set driver_version = "610.43.02" %}
+
+# To update this recipe, bump the versions below and refresh the matching sha256 from
+# https://developer.download.nvidia.com/compute/cuda/redist/redistrib_<cuda_version>.json
+#
+#   cuda_version         the CUDA release the compat libraries are built for
+#   driver_version       "cuda_compat".version, the user-mode driver shipped for linux-64 and sbsa
+#   orin_version         "cuda_compat_orin".version, which follows the CUDA release instead
+#   orin_driver_version  the user-mode driver shipped by "cuda_compat_orin", which the manifest
+#                        does not report: it is the suffix of the library file names inside the
+#                        archive, e.g. compat_orin/libnvidia-nvvm.so.610.01
 {% set cuda_version = "13.3.1" %}
+{% set driver_version = "610.43.02" %}
+{% set orin_version = "13.3.45405995" %}
+{% set orin_driver_version = "610.01" %}
+
 {% set cuda_major_minor = cuda_version.split('.')[:2] | join('.') %}
-{% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
-{% set platform = "linux-sbsa" %}  # [aarch64]
-{% set extension = "tar.xz" %}  # [not win]
 
 # Discrete GPUs get forward compatibility from the "cuda_compat" redistributable, which is
 # versioned after the user-mode driver it ships.
-{% set component = "cuda_compat" %}
-{% set component_version = driver_version + "_cuda" + cuda_major_minor %}
-{% set compat_dir = "compat" %}
-{% set impl_version = driver_version %}
-
+#
 # Tegra cannot reuse the SBSA archive: its libcuda is built against the L4T kernel driver and
 # links against the Tegra NVRM stack (libnvrm_gpu, libnvrm_mem, ...), absent on server ARM.
 # NVIDIA therefore ships the separate "cuda_compat_orin" redistributable, the only supported
-# way to run a CUDA 13 runtime on a Jetson Orin still on JetPack 6.
-# Since CUDA 13 unified the Tegra and SBSA toolkits, it is published under the "linux-sbsa"
-# platform directory, but it keeps its own layout: it is versioned after the CUDA release
-# instead of the driver, and it unpacks into "compat_orin".
+# way to run a CUDA 13 runtime on a Jetson Orin still on JetPack 6. Since CUDA 13 unified the
+# Tegra and SBSA toolkits, it is published under the "linux-sbsa" platform directory, but it
+# keeps its own layout: it is versioned after the CUDA release instead of the driver, and it
+# unpacks into "compat_orin" instead of "compat".
 #
 # Here "arm_variant_type" is only a build-time label telling which redistributable to download.
 # Unlike the CUDA 12 Tegra packages, this build produces sbsa binaries and does not depend on
 # the tegra "arm-variant", see the run requirements below.
-{% set component = "cuda_compat_orin" %}       # [aarch64 and arm_variant_type == "tegra"]
-{% set component_version = "13.3.45405995" %}  # [aarch64 and arm_variant_type == "tegra"]
-{% set compat_dir = "compat_orin" %}           # [aarch64 and arm_variant_type == "tegra"]
-{% set impl_version = "610.01" %}              # [aarch64 and arm_variant_type == "tegra"]
+{% set impl_version = driver_version %}
+{% set impl_version = orin_driver_version %}  # [aarch64 and arm_variant_type == "tegra"]
 
 package:
   name: {{ name|lower }}-split
   version: {{ cuda_version }}
 
 source:
-  url: https://developer.download.nvidia.com/compute/cuda/redist/{{ component }}/{{ platform }}/{{ component }}-{{ platform }}-{{ component_version }}-archive.{{ extension }}
+  url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_compat/linux-x86_64/cuda_compat-linux-x86_64-{{ driver_version }}_cuda{{ cuda_major_minor }}-archive.tar.xz  # [linux64]
   sha256: 39a959840ed06b37ccde9b84c083babe415160c6907517cefc463da6d7dc2342  # [linux64]
+  url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_compat/linux-sbsa/cuda_compat-linux-sbsa-{{ driver_version }}_cuda{{ cuda_major_minor }}-archive.tar.xz  # [aarch64 and arm_variant_type == "sbsa"]
   sha256: 98b044e17e3b9d7ef27ad9bfd231af966744c9fb05b70fb43b5a000dd087952b  # [aarch64 and arm_variant_type == "sbsa"]
+  url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_compat_orin/linux-sbsa/cuda_compat_orin-linux-sbsa-{{ orin_version }}-archive.tar.xz  # [aarch64 and arm_variant_type == "tegra"]
   sha256: d9e7655f46c10eeda7c3652f4fce91825f2b446fab8976c4591bfd4b887e4c8d  # [aarch64 and arm_variant_type == "tegra"]
 
 build:
@@ -45,7 +50,6 @@ build:
   skip: true  # [osx or win or ppc64le]
   script_env:
     - DRV_VERSION={{ impl_version }}
-    - COMPAT_DIR={{ compat_dir }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -123,6 +123,19 @@ outputs:
         # pixi and rattler detect it natively, while conda needs "nvidia-virtual-packages".
         # A run_constrained on a missing virtual package is vacuously satisfied, so without it
         # the two builds stay ambiguous and the solver is free to pick either one.
+        #
+        # Making these hard run requirements would remove that ambiguity, but it cannot be done
+        # here: the conda-forge build image has no "__cuda_arch", so the test environment of
+        # both aarch64 outputs becomes unsolvable and the build fails with
+        # "nothing provides __cuda_arch 8.7.*". conda-forge-ci-setup does export
+        # CONDA_OVERRIDE_CUDA_ARCH, but conda ignores it without "nvidia-virtual-packages", and
+        # it is only exported when "cuda_compiler_version" and "cuda_arch_version" appear in the
+        # rendered .ci_support config, which conda-smithy drops for variant keys the recipe does
+        # not use.
+        #
+        # rattler honours CONDA_OVERRIDE_CUDA_ARCH natively, with no plugin, so this becomes
+        # feasible once the feedstock builds with rattler-build and a recipe.yaml that can refer
+        # to "cuda_arch_version" directly in the specs below.
         - __cuda_arch >=7.5,!=8.7.*  # [aarch64 and arm_variant_type != "tegra"]
         - __cuda_arch 8.7.*          # [aarch64 and arm_variant_type == "tegra"]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,12 +14,17 @@
 {% set compat_dir = "compat" %}
 {% set impl_version = driver_version %}
 
-# Tegra cannot reuse the SBSA archive: its libcuda is built against the L4T kernel driver and links
-# against the Tegra NVRM stack (libnvrm_gpu, libnvrm_mem, ...), which is absent on server ARM. NVIDIA
-# therefore ships the separate "cuda_compat_orin" redistributable, the only supported way to run a
-# CUDA 13 runtime on a Jetson Orin still on JetPack 6. Since CUDA 13 unified the Tegra and SBSA
-# toolkits it is published under the "linux-sbsa" platform directory, but it keeps its own layout:
-# it is versioned after the CUDA release instead of the driver, and it unpacks into "compat_orin".
+# Tegra cannot reuse the SBSA archive: its libcuda is built against the L4T kernel driver and
+# links against the Tegra NVRM stack (libnvrm_gpu, libnvrm_mem, ...), absent on server ARM.
+# NVIDIA therefore ships the separate "cuda_compat_orin" redistributable, the only supported
+# way to run a CUDA 13 runtime on a Jetson Orin still on JetPack 6.
+# Since CUDA 13 unified the Tegra and SBSA toolkits, it is published under the "linux-sbsa"
+# platform directory, but it keeps its own layout: it is versioned after the CUDA release
+# instead of the driver, and it unpacks into "compat_orin".
+#
+# Here "arm_variant_type" is only a build-time label telling which redistributable to download.
+# Unlike the CUDA 12 Tegra packages, this build produces sbsa binaries and does not depend on
+# the tegra "arm-variant", see the run requirements below.
 {% set component = "cuda_compat_orin" %}       # [aarch64 and arm_variant_type == "tegra"]
 {% set component_version = "13.3.45405995" %}  # [aarch64 and arm_variant_type == "tegra"]
 {% set compat_dir = "compat_orin" %}           # [aarch64 and arm_variant_type == "tegra"]
@@ -51,7 +56,6 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("cuda-compat-impl", exact=True) }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - exit 0
@@ -66,6 +70,10 @@ outputs:
         compatibility. This compatibility enables newer CUDA runtimes to work with
         older display drivers. Used for data center GPUs and, with the `tegra`
         variant, for Jetson devices still running a JetPack 6 / L4T driver.
+
+        The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
+        Until this package ships an activation script, they are picked up only if that
+        directory is prepended to `LD_LIBRARY_PATH`.
       doc_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-compat-impl
@@ -73,9 +81,9 @@ outputs:
     files:
       - cuda-compat
     build:
-      # The libnvidia-pkcs11* libs optionally dlopen OpenSSL at runtime. The Tegra libs additionally
-      # link against the L4T NVRM stack and the DLA runtime, which ship with the JetPack BSP on the
-      # device and are resolved there through the system loader configuration.
+      # The libnvidia-pkcs11* libs optionally dlopen OpenSSL at runtime.
+      # The Tegra libs additionally link against the L4T NVRM stack and the DLA runtime, which
+      # ship with the JetPack BSP and are resolved there by the system loader configuration.
       missing_dso_allowlist:
         - '*/libcuda.so*'
         - '*/libcrypto.so*'
@@ -91,11 +99,28 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
       run:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        # Orin moved to the sbsa ABI in CTK 13, so the arm-variant must always be sbsa here.
+        # Requesting the tegra variant would make the package unsolvable together with the
+        # rest of the CUDA 13 stack, which is sbsa only on aarch64.
+        - arm-variant * sbsa  # [aarch64]
+      run_constrained:
+        # Both aarch64 builds depend on the same sbsa arm-variant and only differ by the device
+        # they target, so the compute capability is what tells the solver which one to pick.
+        # Orin is sm_87, and no discrete GPU shares that compute capability.
+        # The other build covers the data center GPUs.
+        # Its lower bound is the minimum architecture supported by CTK 13, since everything
+        # below Turing was dropped there and would gain nothing from a CUDA 13 compat.
+        #
+        # Keep in mind that "__cuda_arch" comes from CEP-46 and is not universally available:
+        # pixi and rattler detect it natively, while conda needs "nvidia-virtual-packages".
+        # A run_constrained on a missing virtual package is vacuously satisfied, so without it
+        # the two builds stay ambiguous and the solver is free to pick either one.
+        - __cuda_arch >=7.5,!=8.7.*  # [aarch64 and arm_variant_type != "tegra"]
+        - __cuda_arch 8.7.*          # [aarch64 and arm_variant_type == "tegra"]
     test:
       commands:
-        # The Tegra libcuda keeps the L4T SONAME libcuda.so.1.1 instead of being versioned after the
-        # driver, and libcudadebugger.so.1 is a regular file there rather than a symlink.
+        # The Tegra libcuda keeps the L4T SONAME libcuda.so.1.1 instead of being versioned
+        # after the driver, and libcudadebugger.so.1 is a regular file rather than a symlink.
         - test -f $PREFIX/cuda-compat/libcuda.so.{{ impl_version }}                      # [not (aarch64 and arm_variant_type == "tegra")]
         - test -f $PREFIX/cuda-compat/libcuda.so.1.1                                     # [aarch64 and arm_variant_type == "tegra"]
         - test -L $PREFIX/cuda-compat/libcuda.so.1
@@ -127,6 +152,10 @@ outputs:
         compatibility. This compatibility enables newer CUDA runtimes to work with
         older display drivers. Used for data center GPUs and, with the `tegra`
         variant, for Jetson devices still running a JetPack 6 / L4T driver.
+
+        The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
+        Until this package ships an activation script, they are picked up only if that
+        directory is prepended to `LD_LIBRARY_PATH`.
       doc_url: https://docs.nvidia.com/cuda/index.html
 
 about:
@@ -140,6 +169,10 @@ about:
     compatibility. This compatibility enables newer CUDA runtimes to work with
     older display drivers. Used for data center GPUs and, with the `tegra`
     variant, for Jetson devices still running a JetPack 6 / L4T driver.
+
+    The libraries are installed in `$PREFIX/cuda-compat`, which is not on the loader path.
+    Until this package ships an activation script, they are picked up only if that
+    directory is prepended to `LD_LIBRARY_PATH`.
   doc_url: https://docs.nvidia.com/cuda/index.html
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ outputs:
       doc_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-compat-impl
-    version: {{ impl_version }}
+    version: "{{ impl_version }}"
     files:
       - cuda-compat
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,8 +58,9 @@ requirements:
 outputs:
   - name: cuda-compat
     build:
-      force_use_keys:
-        - arm_variant_type  # [aarch64]
+      # The two aarch64 builds share name, version and dependencies, so the variant is spelled
+      # out in the build string to make it obvious which shim is installed.
+      string: {{ arm_variant_type }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [aarch64]
     requirements:
       run:
         - {{ pin_subpackage("cuda-compat-impl", exact=True) }}
@@ -87,8 +88,7 @@ outputs:
     files:
       - cuda-compat
     build:
-      force_use_keys:
-        - arm_variant_type  # [aarch64]
+      string: {{ arm_variant_type }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [aarch64]
       # The libnvidia-pkcs11* libs optionally dlopen OpenSSL at runtime.
       # The Tegra libs additionally link against the L4T NVRM stack and the DLA runtime, which
       # ship with the JetPack BSP and are resolved there by the system loader configuration.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,9 @@ requirements:
 
 outputs:
   - name: cuda-compat
+    build:
+      force_use_keys:
+        - arm_variant_type  # [aarch64]
     requirements:
       run:
         - {{ pin_subpackage("cuda-compat-impl", exact=True) }}
@@ -80,6 +83,8 @@ outputs:
     files:
       - cuda-compat
     build:
+      force_use_keys:
+        - arm_variant_type  # [aarch64]
       # The libnvidia-pkcs11* libs optionally dlopen OpenSSL at runtime.
       # The Tegra libs additionally link against the L4T NVRM stack and the DLA runtime, which
       # ship with the JetPack BSP and are resolved there by the system loader configuration.


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

### What changes

This adds a Tegra flavour of `cuda-compat` on `linux-aarch64`, selected through the standard `arm_variant_type` variant, so that the feedstock builds `sbsa` and `tegra` separately instead of assuming SBSA on every ARM build.

The `tegra` variant comes from a different NVIDIA redistributable, `cuda_compat_orin`, which has its own layout:

* It is versioned after the CUDA release (`13.3.45405995`) instead of the user-mode driver, and the driver it actually ships is `610.01`, readable only from the library file names inside the archive, so `cuda-compat-impl` is built as `610.01` there.
* It unpacks into `compat_orin/` instead of `compat/`, so `build.sh` resolves the directory from the archive layout instead of hardcoding it.
* It is published under the `linux-sbsa` platform directory, because CUDA 13 unified the Tegra and SBSA toolkits.

Here `arm_variant_type` is only a build-time label telling which redistributable to download. Unlike the CUDA 12 Tegra packages, this build produces sbsa binaries, so both aarch64 outputs depend on `arm-variant * sbsa`: requesting the tegra variant would make the package unsolvable together with the rest of the CUDA 13 stack, which is sbsa only on `linux-aarch64`.

The remaining changes follow from that:

* The two aarch64 builds carry the variant in the build string, `sbsa_h..._2` and `tegra_h..._2`, so it is visible which shim is installed. `linux-64` keeps its plain build string.
* `run_constrained` advertises the compute capability of the target, `8.7.*` for Orin and `>=7.5,!=8.7.*` for the data center GPUs, which is what disambiguates the two builds on solvers implementing [CEP-46](https://conda.org/learn/ceps/cep-0046/).
* `missing_dso_allowlist` gains the L4T NVRM stack (`libnvrm_gpu`, `libnvrm_mem`, `libnvrm_sync`, `libnvrm_host1x`) and `libnvdla_runtime`, which are provided by the JetPack BSP on the device.
* The tests are adapted to the Tegra layout: `libcuda.so.1.1` keeps the L4T soname rather than being versioned after the driver, `libcudadebugger.so.1` is a regular file rather than a symlink, and `libnvcudla.so` and `libnvcuextend.so` only exist there.
* Build number bumped to 2, since the build string of the existing `sbsa` package changes.

Note that `arm_variant_type` is defined in the global pinning only as `sbsa`, so `tegra` is enabled locally in `recipe/conda_build_config.yaml`, the same way other CUDA feedstocks do it.

### Why

On `aarch64` the recipe always downloaded the SBSA archive, whose `libcuda` is built against the data center kernel driver. That archive cannot load on a Jetson, so there is currently no way to get forward compatibility on those devices from conda-forge.

The concrete case is a Jetson Orin on JetPack 6, where the bundled driver only advertises CUDA 12.6 and anything built for CUDA 13 fails with:

```
RuntimeError: The NVIDIA driver on your system is too old (found version 12060).
```

NVIDIA ships `cuda_compat_orin` exactly for this, and it is the only supported way to run a CUDA 13 runtime there without reflashing to JetPack 7. It is usually installed from a `.deb`, as described in [this NVIDIA forum thread](https://forums.developer.nvidia.com/t/test-run-public-wheels-cuda-13-2-jetson-orin-family/364497), but the same content is available as a redistributable archive, which is what the feedstock already consumes for the other platforms.

### Tested

CI was green on my fork for all three configurations ([run](https://github.com/diegoferigo/cuda-compat-feedstock/actions/runs/30903900237)):

| config | result |
|---|---|
| `linux_64_` | passed |
| `linux_aarch64_arm_variant_typesbsa` | passed |
| `linux_aarch64_arm_variant_typetegra` | passed |

After the review I also rebuilt locally with `build-locally.py`, `linux_64_` and `linux_aarch64_arm_variant_typetegra`, both green with the package tests, and rendered the three configs with `conda render`.

From the `tegra` job:

* The correct archive is fetched, `cuda_compat_orin-linux-sbsa-13.3.45405995-archive.tar.xz`.
* `check-glibc` passes on every library, the highest requirement being 2.25 for `libcudadebugger.so.1`, below the 2.28 pin.
* With `error_overlinking: true` there is no unresolved DSO, every Tegra dependency is matched by the allowlist.

Most importantly, the resulting package was tested on real hardware. On an AGX Orin with JetPack 6, after

```bash
export LD_LIBRARY_PATH="${CONDA_PREFIX}/cuda-compat/:${LD_LIBRARY_PATH:-}"
```

a CUDA 13 PyTorch binary detects and uses the GPU correctly.
